### PR TITLE
make widgets dynamic to dialog size

### DIFF
--- a/browsedatasource.py
+++ b/browsedatasource.py
@@ -28,6 +28,8 @@ class Ui_dataSourceBrowser(object):
     def setupUi(self, dataSourceBrowser):
         dataSourceBrowser.setObjectName(_fromUtf8("dataSourceBrowser"))
         dataSourceBrowser.resize(400, 444)
+        self.verticalLayout = QtWidgets.QVBoxLayout(dataSourceBrowser)
+        self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.buttonBox = QtWidgets.QDialogButtonBox(dataSourceBrowser)
         self.buttonBox.setGeometry(QtCore.QRect(50, 400, 341, 32))
         self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
@@ -36,6 +38,8 @@ class Ui_dataSourceBrowser(object):
         self.dataSourceTree = QtWidgets.QTreeView(dataSourceBrowser)
         self.dataSourceTree.setGeometry(QtCore.QRect(10, 11, 381, 381))
         self.dataSourceTree.setObjectName(_fromUtf8("dataSourceTree"))
+        self.verticalLayout.addWidget(self.dataSourceTree)
+        self.verticalLayout.addWidget(self.buttonBox)
 
         self.retranslateUi(dataSourceBrowser)
         self.buttonBox.accepted.connect(dataSourceBrowser.accept)


### PR DESCRIPTION
I wanted to fix that the tree widget in the select file from browser dialog is not dynamic to the window size. Often, the tree gets wider than the window and expanding the window results in the screenshot below.

<img width="640" height="612" alt="bug_change_datasource_UI" src="https://github.com/user-attachments/assets/13637abd-1671-4c91-bdd3-a67147e434c1" />
